### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,6 @@
 name: Pack and publish nugets
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-legacy-clients/security/code-scanning/4](https://github.com/Altinn/altinn-legacy-clients/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow, either at the top level (applies to all jobs) or under each job specifically (if jobs need different scopes). Review what permissions are required: this workflow checks out code and publishes NuGet packages, likely requiring access to repository contents. For publishing packages, most workflows require `contents: write` for creating releases/tags or uploading artifacts, but you should grant only what is necessary. The fix is to add the following block, right after the workflow's `name:` and before `on:`:
```yaml
permissions:
  contents: write
```
If more granular permission (such as only `read`) suffices, set to `contents: read`, but for publishing new packages, `write` is common. Add this block at the root of `.github/workflows/publish-release.yml` (before `on:`). No changes to other regions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
