### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-legacy-clients/security/code-scanning/2](https://github.com/Altinn/altinn-legacy-clients/security/code-scanning/2)

To fix this problem, explicitly add a `permissions` block to the workflow to limit the access rights of the `GITHUB_TOKEN` as tightly as possible. Since this workflow does not appear to require any write operations (it only builds the project), set `contents: read` either at the root level (applies to all jobs), or under the `build` job (applies only to it). The minimal and recommended fix is to add it at the root level, immediately after the `name` and before the `on` key (line 2), so that all jobs—present and future—default to this minimal permission set. No changes, imports, or definitions are needed other than this YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
